### PR TITLE
Removing C11 static_assert

### DIFF
--- a/src/hal/hal.cpp
+++ b/src/hal/hal.cpp
@@ -151,7 +151,9 @@ u4_t hal_ticks () {
 
     // 0 leads to correct, but overly complex code (it could just return
     // micros() unmodified), 8 leaves no room for the overlapping bit.
-    static_assert(US_PER_OSTICK_EXPONENT > 0 && US_PER_OSTICK_EXPONENT < 8, "Invalid US_PER_OSTICK_EXPONENT value");
+#if US_PER_OSTICK_EXPONENT <= 0 || US_PER_OSTICK_EXPONENT >= 8
+#error "Invalid US_PER_OSTICK_EXPONENT value"
+#endif
 }
 
 // Returns the number of ticks until time. Negative values indicate that


### PR DESCRIPTION
* This is to be able to build without C11 support.